### PR TITLE
Feature: 풀스크린 프로젝트 슬라이더 도입 & 투명 스티키 헤더 적용

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,15 @@
+import ProjectsCoverSlider from "@/features/home/components/ProjectsCoverSlider";
+
 export default function Home() {
   return (
-    <div>홈페이지입니다</div>
+    <main>
+      <ProjectsCoverSlider
+        fullBleed
+        fit="cover"
+        heightClass="h-[100svh]"
+        className="-mt-30" // 헤더 높이 h-14만큼 위로 당김
+      />
+
+    </main>
   );
 }

--- a/src/features/home/components/ProjectsCoverSlider.tsx
+++ b/src/features/home/components/ProjectsCoverSlider.tsx
@@ -1,0 +1,198 @@
+// src/shared/components/projects/ProjectsCoverSlider.tsx
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useProjects } from "@features/projects/api/hooks";
+
+type Props = {
+  className?: string;
+  autoPlay?: boolean;
+  interval?: number;
+  transitionMs?: number;
+  kenBurns?: boolean;
+  fullBleed?: boolean;
+  fit?: "cover" | "contain";
+  heightClass?: string;
+};
+
+export default function ProjectsCoverSlider({
+  className = "",
+  autoPlay = true,
+  interval = 5000,
+  transitionMs = 2500,
+  kenBurns = true,
+  fullBleed = true,
+  fit = "cover",
+  heightClass = "h-[70vh] md:h-[80vh]",
+}: Props) {
+  const router = useRouter();
+  const { data, isLoading, isError, refetch } = useProjects();
+
+  const slides = useMemo(() => {
+    return (
+      data
+        ?.map((p) => ({
+          id: p.projectId,
+          name: p.name,
+          src: p.landCover || p.portCover || null,
+        }))
+        .filter((s) => !!s.src) ?? []
+    );
+  }, [data]);
+
+  const [index, setIndex] = useState(0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const count = slides.length;
+
+  useEffect(() => {
+    if (count === 0) return;
+    setIndex((i) => ((i % count) + count) % count);
+  }, [count]);
+
+  useEffect(() => {
+    if (!autoPlay || count <= 1) return;
+    const t = setInterval(() => {
+      setIsTransitioning(true);
+      setIndex((i) => (i + 1) % count);
+      setTimeout(() => setIsTransitioning(false), transitionMs);
+    }, interval);
+    return () => clearInterval(t);
+  }, [autoPlay, interval, count, transitionMs]);
+
+  // swipe/drag
+  const dragStartX = useRef<number | null>(null);
+  const dragging = useRef(false);
+  const onPointerDown = (e: React.PointerEvent) => {
+    dragging.current = true;
+    dragStartX.current = e.clientX;
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (!dragging.current || dragStartX.current == null) return;
+    const dx = e.clientX - dragStartX.current;
+    dragging.current = false;
+    dragStartX.current = null;
+    const threshold = 40;
+
+    if (dx > threshold) {
+      setIsTransitioning(true);
+      setIndex((i) => (i - 1 + count) % count);
+      setTimeout(() => setIsTransitioning(false), transitionMs);
+    } else if (dx < -threshold) {
+      setIsTransitioning(true);
+      setIndex((i) => (i + 1) % count);
+      setTimeout(() => setIsTransitioning(false), transitionMs);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div
+        className={[
+          fullBleed ? "w-screen mx-[calc(50%-50vw)]" : "w-full",
+          `relative ${heightClass} overflow-hidden`,
+          className,
+        ].join(" ")}
+      >
+        <div className="absolute inset-0 animate-pulse bg-white/5" />
+      </div>
+    );
+  }
+
+  if (isError || count === 0) {
+    return (
+      <div
+        className={[
+          fullBleed ? "w-screen mx-[calc(50%-50vw)]" : "w-full",
+          `grid place-items-center ${heightClass}`,
+          className,
+        ].join(" ")}
+      >
+        {isError ? (
+          <div className="text-sm opacity-80">
+            이미지를 불러오지 못했어요.{" "}
+            <button onClick={() => refetch()} className="underline">
+              다시 시도
+            </button>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  const objectClass = fit === "cover" ? "object-cover" : "object-contain";
+
+  return (
+    <div
+      className={[
+        fullBleed ? "w-screen mx-[calc(50%-50vw)]" : "w-full",
+        "relative select-none",
+        className,
+      ].join(" ")}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      style={{ cursor: dragging.current ? "grabbing" : "grab" }}
+    >
+      <div className={`relative ${heightClass} overflow-hidden bg-black`}>
+        {slides.map((s, i) => {
+          const isActive = i === index;
+          const isPrev = i === (index - 1 + count) % count;
+
+          return (
+            <div
+              key={s.id}
+              className={`absolute inset-0 transition-all ${
+                isActive
+                  ? "opacity-100 z-20"
+                  : isPrev && isTransitioning
+                    ? "opacity-0 z-10"
+                    : "opacity-0 z-0"
+              }`}
+              style={{
+                transitionDuration: `${transitionMs}ms`,
+                transitionTimingFunction: "cubic-bezier(0.4, 0.0, 0.2, 1)",
+              }}
+            >
+              <div className="relative w-full h-full">
+                <Image
+                  src={s.src as string}
+                  alt={s.name}
+                  fill
+                  sizes="100vw"
+                  className={`${objectClass} ${kenBurns && isActive ? "animate-ken-burns" : ""}`}
+                  priority={i === index || i === (index + 1) % count}
+                />
+
+                {/* 오버레이 그라데이션 */}
+                <div className="absolute inset-0 bg-gradient-to-b from-black/20 via-transparent to-black/40 pointer-events-none" />
+
+                <button
+                  aria-label={`${s.name} 상세로 이동`}
+                  onClick={() => router.push(`/projects/${s.id}`)}
+                  className="absolute inset-0 z-30"
+                />
+              </div>
+            </div>
+          );
+        })}
+
+      </div>
+
+      {/* Ken Burns 애니메이션 정의 */}
+      <style jsx>{`
+        @keyframes ken-burns {
+          0% {
+            transform: scale(1);
+          }
+          100% {
+            transform: scale(1.1);
+          }
+        }
+        .animate-ken-burns {
+          animation: ken-burns ${interval}ms ease-out forwards;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -82,7 +82,7 @@ export default function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-40 w-full bg-black text-white">
+    <header className="sticky top-0 z-40 w-full  text-white">
       <div className="mx-auto flex h-14 items-center justify-between px-layout-x-mobile md:px-layout-x-desktop">
         <Link href="/" className="font-extrabold tracking-wide text-24">
           DEEF


### PR DESCRIPTION
### 📝 작업 내용

- * 홈 히어로 영역을 **사진만으로 가로 꽉 차게(Full-bleed)** 보여주고, **부드러운 전환**(페이드 기반)과 **오토플레이/스와이프**를 지원
* 헤더는 콘텐츠 위에 **투명하게 떠있는 느낌**을 유지하되, 기존 레이아웃과 충돌 없이 사용하도록 구성.

### 🔗 관련 이슈

- closes #16 

### ✅ 변경 사항

* **신규**: `ProjectsCoverSlider` 컴포넌트 추가

  * 데이터: `useProjects()` 사용, `landCover → 없으면 portCover`로 커버 이미지 결정
  * 전환: **부드러운 페이드**(조절 가능 `transitionMs`)
  * 자동재생: `interval` 기반 자동 넘김
  * 스와이프: 좌/우 드래그로 이전/다음 전환
  * 레이아웃: `fullBleed`(100vw) + `heightClass`(기본 `100svh`)
  * 옵션: `fit="cover" | "contain"`, `kenBurns`(줌 효과 on/off)
* **홈 적용**: `src/app/page.tsx`에서 히어로에 슬라이더 배치

  * 상단에 **음수 마진** 적용해(예: `-mt-14` 또는 프로젝트 커스텀 스케일 `-mt-30`) 헤더 아래 여백 제거
* **헤더 경미 수정**: 홈에서 투명하게 떠 보이도록 스타일 정리

  * `className="sticky top-0 z-40 w-full text-white"` (배경 제거 → 투명)
  * 홈 히어로와 겹쳐도 텍스트 가독성 확보(히어로에 상단 그라데이션 오버레이 포함)


### 🗂 변경 파일

* `src/features/home/components/ProjectsCoverSlider.tsx` **(신규)**
* `src/app/page.tsx` **(수정)**
* `src/shared/components/layout/Header.tsx` **(스타일 조정)**

### 🔧 구현 상세

**ProjectsCoverSlider API**

```ts
type Props = {
  className?: string;
  autoPlay?: boolean;     // 기본 true
  interval?: number;      // 기본 5000ms
  transitionMs?: number;  // 기본 2500ms (페이드 시간)
  kenBurns?: boolean;     // 기본 true (줌 효과), 필요 없으면 false
  fullBleed?: boolean;    // 기본 true (100vw로 확장)
  fit?: "cover" | "contain"; // 기본 cover
  heightClass?: string;   // 기본 h-[70vh] md:h-[80vh] (홈에선 100svh로 사용)
};
```


### 📸 스크린샷 (선택)

<img width="1470" height="830" alt="스크린샷 2025-10-01 오전 7 01 02" src="https://github.com/user-attachments/assets/347a09ba-d740-4d43-9d61-03fe6c00a885" />
<img width="339" height="734" alt="스크린샷 2025-10-01 오전 7 01 17" src="https://github.com/user-attachments/assets/14a3ceeb-3952-4250-bdef-957192ba8520" />
